### PR TITLE
fix: fix updatePostbackConversionValue iOS 15 crashes and wrong arguments errors

### DIFF
--- a/ios/Tenjin.mm
+++ b/ios/Tenjin.mm
@@ -58,19 +58,33 @@ RCT_EXPORT_METHOD(appendAppSubversion:(NSNumber * _Nonnull)version)
     [TenjinSDK appendAppSubversion:version];
 }
 
+// We must name updatePostbackConversionValue differently for each different
+// signature because React Native doesn't support different arities of arguments
+// with the same name.
+//
+// See https://github.com/facebook/react-native/issues/12498
+
 RCT_EXPORT_METHOD(updatePostbackConversionValue:(NSNumber * _Nonnull)conversionValue)
 {
     [TenjinSDK updatePostbackConversionValue:[conversionValue intValue]];
 }
 
-RCT_EXPORT_METHOD(updatePostbackConversionValue:(NSNumber * _Nonnull)conversionValue coarseValue:(NSString * _Nonnull)coarseValue)
+RCT_EXPORT_METHOD(updatePostbackConversionValueWithCoarseValue:(NSNumber * _Nonnull)conversionValue coarseValue:(NSString * _Nonnull)coarseValue)
 {
-    [TenjinSDK updatePostbackConversionValue:[conversionValue intValue] coarseValue:coarseValue];
+    if (@available(iOS 16.1, *)) {
+        [TenjinSDK updatePostbackConversionValue:[conversionValue intValue] coarseValue:coarseValue];
+    } else {
+        [TenjinSDK updatePostbackConversionValue:[conversionValue intValue]];
+    }
 }
 
-RCT_EXPORT_METHOD(updatePostbackConversionValue:(NSNumber * _Nonnull)conversionValue coarseValue:(NSString * _Nonnull)coarseValue lockWindow:(BOOL)lockWindow)
+RCT_EXPORT_METHOD(updatePostbackConversionValueWithCoarseValueAndLockWindow:(NSNumber * _Nonnull)conversionValue coarseValue:(NSString * _Nonnull)coarseValue lockWindow:(BOOL)lockWindow)
 {
-    [TenjinSDK updatePostbackConversionValue:[conversionValue intValue] coarseValue:coarseValue lockWindow:lockWindow];
+    if (@available(iOS 16.1, *)) {
+        [TenjinSDK updatePostbackConversionValue:[conversionValue intValue] coarseValue:coarseValue lockWindow:lockWindow];
+    } else {
+        [TenjinSDK updatePostbackConversionValue:[conversionValue intValue]];
+    }
 }
 
 RCT_EXPORT_METHOD(getAttributionInfo:(RCTResponseSenderBlock)successCallback errorCallback: (RCTResponseSenderBlock)errorCallback)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,8 +6,34 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
-const Tenjin = NativeModules.Tenjin
-  ? NativeModules.Tenjin
+export type TenjinCoarseConversionValue = 'low' | 'medium' | 'high';
+
+const nativeTenjin = NativeModules.Tenjin;
+
+const Tenjin = nativeTenjin
+  ? {
+      ...nativeTenjin,
+      updatePostbackConversionValue: (
+        conversionValue: number,
+        coarseValue?: TenjinCoarseConversionValue,
+        lockWindow?: number
+      ) => {
+        if (lockWindow) {
+          return nativeTenjin.updatePostbackConversionValueWithCoarseValueAndLockWindow(
+            conversionValue,
+            coarseValue,
+            lockWindow
+          );
+        } else if (coarseValue) {
+          return nativeTenjin.updatePostbackConversionValueWithCoarseValue(
+            conversionValue,
+            coarseValue
+          );
+        } else {
+          return nativeTenjin.updatePostbackConversionValue(conversionValue);
+        }
+      },
+    }
   : new Proxy(
       {},
       {


### PR DESCRIPTION
**Motivation**

No internal JIRA; however, when using the Tenjin SDK in production, we saw that:

- On iOS 15, we were getting crashes when we tried calling `updatePostbackConversionValue`, as this would default to the 3-argument `updatePostbackConversionValue` (since it's the last one exported using RCT_
- On iOS 16+, we were getting the below errors when we tried to call `updatePostbackConversionValue` with a single argument

<details>
  <summary>Screenshot of our production error in Bugsnag in iOS 15: `+[SKAdNetwork updatePostbackConversionValue:completionHandler:]: unrecognized selector sent to class 0x1e7609c90`</summary>

  From https://app.bugsnag.com/travelchime-inc/wanderlog-mobile/errors/653ff216cecd830008ed4929?filters[event.unhandled]=true&filters[event.since]=30d&filters[app.release_stage]=production (Internal link)

![image](https://github.com/tenjin/tenjin-react-native-sdk/assets/2924388/6fa53af2-4904-4888-be87-86a6399939db)
</details>


<details>
  <summary>Screenshot of a dev error in iOS 16.1+</summary>

![Untitled](https://github.com/tenjin/tenjin-react-native-sdk/assets/2924388/02ad294d-5e14-4b43-94e6-f5c888fdcedb)
</details>



**Proposed Changes:**

- Add checks for iOS version number before trying to call versions of the updatePostbackConversionValue function only available in iOS 16+: https://developer.apple.com/documentation/storekit/skadnetwork/4097267-updatepostbackconversionvalue
- Change the native modules methods for updatePostbackConversionValue so that they're named differently

**Steps:**

- [ ] Reviewed
- [ ] Deployed to Staging
- [ ] QA'd
- [ ] Deployed to Production
- [ ] Add release information to https://adromance.atlassian.net/wiki/spaces/TJ/pages/2154397697/QA+for+SDK+version+update+-+React+Native