### PR TITLE
fix: break self-referential JSONObject type that overflows codegen on RN 0.85+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tenjin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tenjin is a unique growth infrastructure platform that helps you streamline your mobile marketing.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/NativeTenjin.ts
+++ b/src/NativeTenjin.ts
@@ -1,6 +1,9 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
+// Intentionally non-recursive: RN 0.85+ codegen overflows on a self-referential type
+// alias during `pod install`. Types are erased at runtime, so the native bridge still
+// gets the full nested object. See PR #60.
 type JSONObject = {
   [key: string]: string | number | boolean | null;
 };

--- a/src/NativeTenjin.ts
+++ b/src/NativeTenjin.ts
@@ -2,7 +2,7 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 type JSONObject = {
-  [key: string]: string | number | boolean | null | JSONObject | JSONObject[];
+  [key: string]: string | number | boolean | null;
 };
 
 export interface Spec extends TurboModule {

--- a/src/NativeTenjin.ts
+++ b/src/NativeTenjin.ts
@@ -1,9 +1,7 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
-// Intentionally non-recursive: RN 0.85+ codegen overflows on a self-referential type
-// alias during `pod install`. Types are erased at runtime, so the native bridge still
-// gets the full nested object. See PR #60.
+// Non-recursive by design: RN 0.84+ codegen stack-overflows on a self-referential alias. See PR #60.
 type JSONObject = {
   [key: string]: string | number | boolean | null;
 };


### PR DESCRIPTION
## Problem

On React Native 0.85+ (Expo SDK 56), `pod install` fails during codegen:

```
[Codegen] RangeError: Maximum call stack size exceeded
```

## Root cause

`src/NativeTenjin.ts` defines a recursive type alias:

```ts
type JSONObject = {
  [key: string]: string | number | boolean | null | JSONObject | JSONObject[];
};
```

React Native 0.85's codegen TypeScript parser now eagerly resolves type aliases (`getResolvedTypeAnnotation`). Processing the `JSONObject` index-signature union re-resolves `JSONObject` within itself and recurses with no depth guard:

```
TypeScriptParser.getResolvedTypeAnnotation
  -> translateTypeAnnotation
  -> emitUnion
  -> translateTypeAnnotation -> getResolvedTypeAnnotation -> ... (infinite)
```

React Native <= 0.83 did not resolve the alias this way, so codegen completed. As a result, any app on RN 0.85+ / Expo SDK 56+ that depends on `react-native-tenjin` cannot finish `pod install`. The latest release (1.4.0) has the same type.

## Fix

Break the self-reference. `JSONObject` is internal to the spec and only types parameters passed across the bridge — TypeScript types are erased at runtime, so the native module still receives the full (possibly nested) object; only the static type is narrowed:

```diff
 type JSONObject = {
-  [key: string]: string | number | boolean | null | JSONObject | JSONObject[];
+  [key: string]: string | number | boolean | null;
 };
```

(Alternatively, React Native's codegen `UnsafeObject` type expresses "an arbitrary object" more faithfully — glad to switch to that if you prefer.)

## Verification

With this change, codegen completes and generates artifacts successfully during `pod install` on RN 0.85.3 / Expo SDK 56.
