### PR TITLE
build: update Android and iOS SDK versions [TENJIN-28772]

### DIFF
--- a/Tenjin.podspec
+++ b/Tenjin.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
     'SWIFT_OBJC_INTEROP_MODE' => 'objcxx',
   }
 
-  s.dependency "TenjinSDK", "1.17.2"
+  s.dependency "TenjinSDK", "1.18.0"
 
  install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,7 +74,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.tenjin:android-sdk:1.21.0'
+  implementation 'com.tenjin:android-sdk:1.22.0'
 }
 
 react {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tenjin",
-  "version": "1.5.2",
+  "version": "1.5.1",
   "description": "Tenjin is a unique growth infrastructure platform that helps you streamline your mobile marketing.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tenjin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Tenjin is a unique growth infrastructure platform that helps you streamline your mobile marketing.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tenjin",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Tenjin is a unique growth infrastructure platform that helps you streamline your mobile marketing.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary
- Android SDK: 1.21.0 → 1.22.0 (`android/build.gradle`)
- iOS SDK: 1.17.2 → 1.18.0 (`Tenjin.podspec` dependency)
- Bumps package version 1.5.0 → 1.5.1 to match, following the same pattern as the last native SDK bump (#69). Both native bumps ship together in this PR, so the wrapper version only moves once.

Jira: TENJIN-28772

## Test plan
- [ ] CI green