### PR TITLE
docs: document cache event setting and its persistence [TENJIN-28758]

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ Tenjin.getAnalyticsInstallationId()
 ```
 Returns: callback -> `string`
 
+### Retry/cache events and IAP
+You can enable/disable retrying and caching events and IAP when requests fail or users don't have internet connection. These events will be sent after a new event has been added to the queue and user has recovered connection.
+
+```javascript
+Tenjin.setCacheEventSetting(true)
+```
+Parameters:
+- `setting`: boolean
+
+> [!IMPORTANT]
+> This setting is stored on the device and persists across app sessions on both iOS and Android. Once a build has enabled it, removing the `setCacheEventSetting` call in a later release will **not** disable caching for existing users, because the previously stored value stays in effect. To turn it off, explicitly call `Tenjin.setCacheEventSetting(false)`.
+
 ### User Profile - LiveOps Metrics
 
 The Tenjin SDK automatically tracks user engagement metrics to help you understand player behavior and lifetime value. These metrics are collected automatically and can be accessed programmatically.


### PR DESCRIPTION
## Summary
The plugin exposes `setCacheEventSetting` but the README never documented it. Adds a *Retry/cache events and IAP* section explaining what it does, plus a note that the value is stored on the device and persists across app sessions, so removing the call from a later build does **not** disable caching for users who already had it enabled. Apps must call `Tenjin.setCacheEventSetting(false)` explicitly.

## Context
A customer removed the call expecting caching to be disabled and spent time debugging under that assumption. Companion PRs: tenjin/tenjin-ios-sdk#194, tenjin/tenjin-android-sdk#147, tenjin/tenjin-unity-sdk#205, tenjin/flutter-sdk#49.

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)