### PR TITLE
build: align release-please tag format with existing release tags [TENJIN-28888]

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,7 @@
       "changelog-path": "CHANGELOG.md",
       "package-name": "react-native-tenjin"
     }
-  }
+  },
+  "include-v-in-tag": false,
+  "tag-format": "${version}"
 }


### PR DESCRIPTION
## Summary
- `release-please-config.json` had no `tag-format` set, so release-please defaulted to component-prefixed tags like `react-native-tenjin-v1.6.0`.
- Our actual release history (tagged by the old `release-it` flow, e.g. `1.5.1`, `1.5.0`, ...) uses plain version numbers with no package-name or `v` prefix.
- Without a matching anchor tag, release-please couldn't find the last release point and replayed the full commit history, re-listing already-shipped features/fixes as new — see #81, which resurrects the LiveOps UserProfile, CloudX ILRD, and other commits already released before `1.5.1`.
- Fix: set `"include-v-in-tag": false` and `"tag-format": "${version}"` so release-please's tag expectations match the repo's actual tags.
- This mirrors the fix already applied on the Android SDK for the same issue (TENJIN-27992).

## Follow-up
- PR #81 (the stale release PR) should be closed and its branch (`release-please--branches--master--components--react-native-tenjin`) deleted once this merges, so release-please regenerates a correct, minimal release PR from a clean state.

## Test plan
- [x] JSON syntax validated
- [ ] Confirm release-please regenerates a correct (non-stale) release PR after this merges