### PR TITLE
fix: use include-component-in-tag instead of invalid tag-format key [TENJIN-28888]

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,5 +8,5 @@
     }
   },
   "include-v-in-tag": false,
-  "tag-format": "${version}"
+  "include-component-in-tag": false
 }


### PR DESCRIPTION
## Summary
Follow-up to #83, which didn't fully fix the tag mismatch.

- `"tag-format": "${version}"` is **not a valid release-please config key** — checked against the [official schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json). It was silently ignored.
- Only `include-v-in-tag: false` took effect, which is why PR #81 updated to drop the `v` (`react-native-tenjin-v1.5.1` → `react-native-tenjin-1.5.1`) but kept the `react-native-tenjin-` component prefix.
- The real key for this is `include-component-in-tag` (default `true`) — set to `false` so tags come out as plain `1.5.1`-style versions, matching our actual release history.

## Test plan
- [x] Verified against release-please's published config schema
- [ ] Confirm PR #81 regenerates with a plain version tag (e.g. `1.5.1`/`1.5.2`) and no resurrected historical changelog entries after this merges